### PR TITLE
Automate db:migrate on merge

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,31 @@
+name: Run Drizzle migrations on main when schema or migrations change
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'app/src/lib/schema.ts'
+      - 'app/migrations/**'
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies (app)
+        working-directory: app
+        run: bun install
+
+      - name: Run migrations
+        working-directory: app
+        run: bun run db:migrate


### PR DESCRIPTION
Add a GitHub Actions workflow to automatically run Drizzle migrations on `main` when schema or migration files are updated.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac1ffa79-deb7-4c9b-8f0c-517840e102e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac1ffa79-deb7-4c9b-8f0c-517840e102e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an automated CI workflow to apply database migrations after relevant changes are merged into the main branch. This keeps the database schema in sync with code changes, reduces manual steps, and improves deployment reliability. The workflow runs in a controlled environment using secure connection settings, installs necessary dependencies, and executes migrations. No user-facing changes or behavior adjustments are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->