### PR TITLE
Remove bun run build from github action

### DIFF
--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -30,11 +30,6 @@ jobs:
       - name: 🔍 Type check
         working-directory: app
         run: bun run typecheck
-
-      - name: ⎔ Build
-        working-directory: app
-        run: bun run build
-
       - name: 🏄 Run the tests
         run: echo "No tests configured yet. Add tests as needed."
 


### PR DESCRIPTION
Remove `bun run build` from the PR/commit GitHub Action to prevent Zod/environment variable errors during CI.

The `bun run build` step was failing in CI with Zod errors related to missing environment variables, which indicates a runtime configuration issue rather than a build-time problem. Removing this step allows PRs to pass CI without these irrelevant build failures, while still maintaining format and type checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-84fe3e53-2b2c-415b-afc9-28dda37eb012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-84fe3e53-2b2c-415b-afc9-28dda37eb012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

